### PR TITLE
Prevent an exception-handling routine from failing with pythonw

### DIFF
--- a/src/robotide/spec/librarymanager.py
+++ b/src/robotide/spec/librarymanager.py
@@ -80,7 +80,10 @@ class LibraryManager(Thread):
                 library_name.replace('/', os.sep), os.path.abspath('.'))
             return get_import_result(path, library_args)
         except Exception, err:
-            print 'FAILED', library_name, err
+            try:
+                print 'FAILED', library_name, err
+            except IOError:
+                pass
             kws = self._spec_initializer.init_from_spec(library_name)
             if not kws:
                 msg = 'Importing test library "%s" failed' % library_name


### PR DESCRIPTION
On Windows, when running RIDE via pythonw.exe,  the `print` statement throws an error (IO Error 9: Bad file descriptor) because there is no console to write to.

But this except-block is a normal part of handling libraries written in Java. For those libraries, Python code does not exist, so documentation may be imported via XML files. 

When this happens, the print keyword fails and is reported to RIDE, where it clutters the RIDE log. Instead, it should fail silently.